### PR TITLE
fix: align static daemonset with v0.2.0 image

### DIFF
--- a/deployments/static/npu-feature-discovery-daemonset.yaml
+++ b/deployments/static/npu-feature-discovery-daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: node-feature-discovery
   labels:
     app.kubernetes.io/name: rbln-npu-feature-discovery
-    app.kubernetes.io/version: v0.1.4
+    app.kubernetes.io/version: v0.2.0
 spec:
   selector:
     matchLabels:
@@ -14,10 +14,10 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rbln-npu-feature-discovery
-        app.kubernetes.io/version: v0.1.4
+        app.kubernetes.io/version: v0.2.0
     spec:
       containers:
-        - image: rebellions/rbln-npu-feature-discovery:v0.1.4
+        - image: rebellions/rbln-npu-feature-discovery:v0.2.0
           name: rbln-npu-feature-discovery
           command: ["/usr/local/bin/rbln-npu-feature-discovery"]
           volumeMounts:

--- a/deployments/static/npu-feature-discovery-job.yaml.template
+++ b/deployments/static/npu-feature-discovery-job.yaml.template
@@ -5,17 +5,17 @@ metadata:
   namespace: node-feature-discovery
   labels:
     app.kubernetes.io/name: rbln-npu-feature-discovery
-    app.kubernetes.io/version: 0.1.1
+    app.kubernetes.io/version: v0.2.0
 spec:
   template:
     metadata:
       labels:
         app.kubernetes.io/name: rbln-npu-feature-discovery
-        app.kubernetes.io/version: 0.1.1
+        app.kubernetes.io/version: v0.2.0
     spec:
       nodeName: NODE_NAME
       containers:
-        - image: rebellions/rbln-npu-feature-discovery:0.1.1
+        - image: rebellions/rbln-npu-feature-discovery:v0.2.0
           name: rbln-npu-feature-discovery
           command: ["/usr/local/bin/rbln-npu-feature-discovery"]
           args:


### PR DESCRIPTION
## Motivation
After tagging `v0.2.0`, the static DaemonSet manifest under `deployments/static` was not updated and still references the `v0.1.4` image along with its old binary path. Installing from the published YAML therefore pulls an outdated image that lacks `/usr/local/bin/rbln-npu-feature-discovery`, causing the container to crash. We need to synchronize the manifest with the latest release so out-of-the-box installs work.

## Summary of Changes
- Update `deployments/static/npu-feature-discovery-daemonset.yaml` to use the `rebellions/rbln-npu-feature-discovery:v0.2.0` image.
- Ensure the manifest’s command path matches the binary location baked into the v0.2.0 container.
- Closes https://github.com/rebellions-sw/rbln-npu-feature-discovery/issues/4

## Technical Details
- The `v0.2.0` image contains the Go-based binary at `/usr/local/bin/rbln-npu-feature-discovery`; the manifest now invokes that path explicitly.
- No other deployment knobs changed; this is strictly a version/path alignment so the DaemonSet-installed pods run the current release.