### PR TITLE
ci: switch GitHub Actions runner to ubuntu-latest

### DIFF
--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   go-build:
     name: golang build npu feature discovery
-    runs-on: ubuntu-latest-rbln
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         name: Checkout code

--- a/.github/workflows/go-checks.yaml
+++ b/.github/workflows/go-checks.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   code-check:
     name: golang code checks
-    runs-on: ubuntu-latest-rbln
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         name: Checkout code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   build-and-push-image:
     name: Build and push image
-    runs-on: ubuntu-latest-rbln
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
   draft-release:
     needs:
       - build-and-push-image
-    runs-on: ubuntu-latest-rbln
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/trigger-ci.yaml
+++ b/.github/workflows/trigger-ci.yaml
@@ -17,7 +17,7 @@ jobs:
   build-and-push-image:
     needs: [code-check, go-build]
     name: Build and push RBLN metrics exporter image
-    runs-on: ubuntu-latest-rbln
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/trigger-pr.yaml
+++ b/.github/workflows/trigger-pr.yaml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   pr-title-validation:
-    runs-on: ubuntu-latest-rbln
+    runs-on: ubuntu-latest
     steps:
       - name: Validate PR title
         uses: amannn/action-semantic-pull-request@v5
@@ -49,7 +49,7 @@ jobs:
   build-image:
     needs: [code-check, go-build]
     name: Build RBLN NPU Feature Discovery image
-    runs-on: ubuntu-latest-rbln
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
## Motivation

The custom runner ubuntu-latest-rbln is no longer required and caused inconsistencies in CI execution. Switching to the standard GitHub runner improves reliability and portability.

## Summary of Changes

Updated runs-on from ubuntu-latest-rbln to ubuntu-latest in the build-and-push-image job.