### PR TITLE
fix(collector): map device id 2030 to CR03

### DIFF
--- a/internal/collector/device.go
+++ b/internal/collector/device.go
@@ -21,6 +21,7 @@ var deviceProductMap = map[string]DeviceProduct{
 	"1220": "CA22",
 	"1221": "CA22",
 	"1250": "CA25",
+	"2030": "CR03",
 }
 
 func productFromDeviceID(id string) (DeviceProduct, error) {


### PR DESCRIPTION
## Motivation
The collector failed with `unknown device id: 2030` when running on nodes with CR03 devices.
This prevented feature discovery from generating NPU and driver-version labels.

## Summary of Changes
- Added a device product mapping for PCI device ID `2030`
- Mapped `2030` to `CR03` so feature collection can proceed normally
