### PR TITLE
ci: build per-arch images on dedicated runners and publish multi-arch manifest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,34 +9,79 @@ permissions:
   contents: write
 
 jobs:
-  build-and-push-image:
-    name: Build and push image
+  build-amd64:
+    name: Build and push amd64 image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v3
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-      - name: Build and push RBLN npu feature discovery image
+      - name: Build and push amd64 image
         env:
-          VERSION: ${{ github.ref_name }}
+          VERSION: ${{ github.ref_name }}-amd64
           REGISTRY: docker.io/rebellions
           PUSH_ON_BUILD: "true"
-          BUILD_MULTI_PLATFORM: "false" # TODO(mskim): revert when dedicated ARM runners become available
+          PLATFORM: linux/amd64
         run: make build-image
+
+  build-arm64:
+    name: Build and push arm64 image
+    runs-on: ubuntu-22.04-rbln-arm
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Build and push arm64 image
+        env:
+          VERSION: ${{ github.ref_name }}-arm64
+          REGISTRY: docker.io/rebellions
+          PUSH_ON_BUILD: "true"
+          PLATFORM: linux/arm64
+        run: make build-image
+
+  manifest:
+    name: Create multi-arch manifest
+    needs: [build-amd64, build-arm64]
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: docker.io/rebellions/rbln-npu-feature-discovery
+    steps:
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Create version and latest manifests
+        run: |
+          docker buildx imagetools create \
+            --tag "${IMAGE}:${{ github.ref_name }}" \
+            "${IMAGE}:${{ github.ref_name }}-amd64" \
+            "${IMAGE}:${{ github.ref_name }}-arm64"
+          docker buildx imagetools create \
+            --tag "${IMAGE}:latest" \
+            "${IMAGE}:${{ github.ref_name }}-amd64" \
+            "${IMAGE}:${{ github.ref_name }}-arm64"
 
   draft-release:
     needs:
-      - build-and-push-image
+      - manifest
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/.github/workflows/trigger-ci.yaml
+++ b/.github/workflows/trigger-ci.yaml
@@ -16,26 +16,48 @@ jobs:
     uses: ./.github/workflows/go-build.yaml
   build-and-push-image:
     needs: [code-check, go-build]
-    name: Build and push RBLN metrics exporter image
-    runs-on: ubuntu-latest
+    name: Build and push RBLN npu feature discovery image
+    runs-on: rbln-sw-k8s-general
+    env:
+      IMAGE: harbor.k8s.rebellions.in/rebellions/rbln-npu-feature-discovery
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: Install prerequisites
+        run: |
+          if ! command -v docker &>/dev/null; then
+            curl -fsSL https://get.docker.com | sudo sh
+            sudo usermod -aG docker "$USER"
+            sudo chmod 666 /var/run/docker.sock
+          fi
+          if ! command -v make &>/dev/null; then
+            sudo apt-get update && sudo apt-get install -y make
+          fi
+
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
+      - name: Login to Harbor
         uses: docker/login-action@v3
         with:
-          registry: docker.io
+          registry: harbor.k8s.rebellions.in
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
+
+      - name: Login to Docker Hub for base-image pulls
+        uses: docker/login-action@v3
+        with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build and push image
         env:
-          VERSION: "latest"
-          REGISTRY: docker.io/rebellions
+          VERSION: ${{ github.sha }}
+          REGISTRY: harbor.k8s.rebellions.in/rebellions
           PUSH_ON_BUILD: "true"
           BUILD_MULTI_PLATFORM: "false" # TODO(mskim): revert when dedicated ARM runners become available
         run: make build-image
+
+      - name: Tag dev (alias of the immutable commit SHA)
+        run: docker buildx imagetools create --tag "${IMAGE}:dev" "${IMAGE}:${GITHUB_SHA}"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 bin/*
 
 .go-version
+CLAUDE.md

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,14 @@ BUILD_MULTI_PLATFORM ?= false
 DOCKER_BUILD_OPTIONS ?= --output=type=image,push=$(PUSH_ON_BUILD)
 BUILDX =
 
-ifeq ($(BUILD_MULTI_PLATFORM),true)
+# PLATFORM can be set to a single platform (e.g. linux/amd64, linux/arm64)
+# to override the default multi-platform logic.
+PLATFORM ?=
+
+ifneq ($(PLATFORM),)
+	DOCKER_BUILD_PLATFORM_OPTIONS := --platform=$(PLATFORM)
+	BUILDX = buildx
+else ifeq ($(BUILD_MULTI_PLATFORM),true)
 	DOCKER_BUILD_PLATFORM_OPTIONS ?= --platform=linux/amd64,linux/arm64
 	BUILDX = buildx
 else


### PR DESCRIPTION
##  Motivation

  The release and CI image builds relied on a BUILD_MULTI_PLATFORM: "false" workaround because no dedicated ARM runner was available, so only amd64 images were published. Now that an arm64 runner exists, we can produce native
  multi-arch images and route CI builds to our internal Harbor registry.

##  Summary of Changes

  - Split the release build into separate build-amd64 and build-arm64 jobs, then combine them into multi-arch :<version> and :latest manifests.
  - Point the CI (trigger-ci) image build at Harbor, tag by commit SHA, and add a mutable dev alias.
  - Add a PLATFORM override to the Makefile so a single target arch can be built per job.