### PR TITLE
ci: install docker and make prerequisites in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,16 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+      - name: Install prerequisites
+        run: |
+          if ! command -v docker &>/dev/null; then
+            curl -fsSL https://get.docker.com | sudo sh
+            sudo usermod -aG docker "$USER"
+            sudo chmod 666 /var/run/docker.sock
+          fi
+          if ! command -v make &>/dev/null; then
+            sudo apt-get update && sudo apt-get install -y make
+          fi
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub


### PR DESCRIPTION
##  Motivation

  The release workflow assumed docker and make were already present on the runner. On runners where they are missing, the build steps fail before the image can be built.

##  Summary of Changes
  - Add an "Install prerequisites" step to the release job that installs docker and make when they are not already available.