### PR TITLE
feat(collector): drop npu.family label emission

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -41,12 +41,26 @@ env:
 
   # Driver/daemon chart defaults (repo.rebellions.ai) aren't pullable yet, so
   # override to the dev registry — same values as the operator nightly.
+  #
+  # Family separation: registry/repository stay family-AGNOSTIC — the operator
+  # splices the family segment into the pull path per node pool
+  # (rebellions-dev/<family>/rbln-driver:<ver>-<kernel>-<os>), so the version is
+  # pinned per family. The retired global SENTINEL_DRIVER_IMAGE_TAG applied one
+  # version to every family; 3.2.0 has no atom build for this cluster's
+  # ubuntu22.04 kernels and no rebel100 build at all, so it now fails the
+  # operator's driver image check (DriverImageNotFound) instead of installing.
   SENTINEL_DRIVER_IMAGE_REGISTRY: harbor.ssw.rbln.in
   SENTINEL_DRIVER_IMAGE_REPOSITORY: rebellions-dev/rbln-driver
-  SENTINEL_DRIVER_IMAGE_TAG: "${SENTINEL_DRIVER_IMAGE_TAG:-3.2.0}"
+  SENTINEL_ATOM_DRIVER_VERSION: "${SENTINEL_ATOM_DRIVER_VERSION:-3.2.2}"
+  SENTINEL_REBEL100_DRIVER_VERSION: "${SENTINEL_REBEL100_DRIVER_VERSION:-3.3.0-rc3}"
+  # NPU family set. Pinned rather than auto-detected (npu.family labels ->
+  # NodeFeature PCI fallback) so a node that is temporarily unlabeled cannot
+  # silently shrink the set and change which RBLNDriver CRs get rendered.
+  SENTINEL_NPU_FAMILIES: "${SENTINEL_NPU_FAMILIES:-atom,rebel100}"
   SENTINEL_RBLN_DAEMON_IMAGE_REGISTRY: harbor.ssw.rbln.in
   SENTINEL_RBLN_DAEMON_IMAGE_REPOSITORY: rebellions-dev/rbln-daemon
-  SENTINEL_RBLN_DAEMON_IMAGE_TAG: "${SENTINEL_RBLN_DAEMON_IMAGE_TAG:-3.2.0}"
+  # Paired with the atom driver above; rbln-daemon is not family-split.
+  SENTINEL_RBLN_DAEMON_IMAGE_TAG: "${SENTINEL_RBLN_DAEMON_IMAGE_TAG:-3.2.2}"
 
 agents:
   queue: "k8s"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ RBLN NPU Feature Discovery automatically publishes Kubernetes node labels descri
 
 ## Overview
 
-The binary inspects sysfs: devices are discovered under `/sys/bus/pci/devices` (vendor `0x1eff`), and the product name is resolved from the driver's `card_name` attribute under `/sys/class/rebellions` first, falling back to the bundled `pci.ids` Rebellions vendor block for drivers that predate `card_name`. If neither source resolves the product, only `npu.product`/`npu.family` are omitted — the remaining labels are still written. All collected facts are stored in `/etc/kubernetes/node-feature-discovery/features.d/rbln-features`, which NFD reads through the `local` feature source.
+The binary inspects sysfs: devices are discovered under `/sys/bus/pci/devices` (vendor `0x1eff`), and the product name is resolved from the driver's `card_name` attribute under `/sys/class/rebellions` first, falling back to the bundled `pci.ids` Rebellions vendor block for drivers that predate `card_name`. If neither source resolves the product, only `npu.product` is omitted — the remaining labels are still written. All collected facts are stored in `/etc/kubernetes/node-feature-discovery/features.d/rbln-features`, which NFD reads through the `local` feature source.
 
 | Component | Purpose |
 |-----------|---------|
@@ -37,7 +37,6 @@ Customize namespace, tolerations, image registry, or resource requests as needed
 Once both NFD and RBLN NPU Feature Discovery are running, inspect a node with `kubectl get node <npu-node> -o yaml`. The `metadata.labels` section should now include keys such as:
 - `rebellions.ai/npu.present=true`
 - `rebellions.ai/npu.count=2`
-- `rebellions.ai/npu.family=ATOM`
 - `rebellions.ai/npu.product=RBLN-CA12`
 - `rebellions.ai/driver-version.full=1.2.92-6d00b56`
 - `rebellions.ai/driver-version.major=1`
@@ -52,7 +51,6 @@ Label values are stored as strings in Kubernetes. The “Value type” column de
 |-------|------------|-------------|----------|
 | `rebellions.ai/npu.present` | Boolean | Indicates if any RBLN NPU was detected on the node. | `true`, `false` |
 | `rebellions.ai/npu.count` | Integer | Number of NPUs after filtering out PFs that own SR-IOV VFs. | `1`, `2` |
-| `rebellions.ai/npu.family` | String | Architecture family derived from the PCI product code. | `ATOM`, `REBEL` |
 | `rebellions.ai/npu.product` | String | Product name (e.g., `RBLN-CA22`, `RBLN-CR22`). | `RBLN-CA22`, `RBLN-CR22` |
 | `rebellions.ai/driver-version.full` | String | Full semantic version reported by the driver, including optional revision suffix. | `1.2.92-6d00b56` |
 | `rebellions.ai/driver-version.major` | Integer | Major component of the driver version. | `1` |

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -17,7 +17,6 @@ const labelPrefix = "rebellions.ai"
 type Features struct {
 	NPUPresent            bool
 	NPUCount              *int
-	NPUFamily             *string
 	NPUProduct            *string
 	DriverVersionFull     *string
 	DriverVersionMajor    *string
@@ -35,9 +34,6 @@ func (f Features) toPlainText() string {
 	fmt.Fprintf(&b, "%s/npu.present=%t\n", labelPrefix, f.NPUPresent)
 	if f.NPUCount != nil {
 		fmt.Fprintf(&b, "%s/npu.count=%d\n", labelPrefix, *f.NPUCount)
-	}
-	if f.NPUFamily != nil {
-		fmt.Fprintf(&b, "%s/npu.family=%s\n", labelPrefix, *f.NPUFamily)
 	}
 	if f.NPUProduct != nil {
 		fmt.Fprintf(&b, "%s/npu.product=%s\n", labelPrefix, *f.NPUProduct)
@@ -148,22 +144,15 @@ func (c *FeaturesCollector) resolveProduct(deviceID string) string {
 	return ""
 }
 
-// applyProduct sets NPUProduct/NPUFamily. An unresolved product only costs
-// these two labels — never the rest of the feature file — so a new SKU
-// cannot expire npu.present/npu.count on the node.
+// applyProduct sets NPUProduct. An unresolved product only costs this label —
+// never the rest of the feature file — so a new SKU cannot expire
+// npu.present/npu.count on the node.
 func applyProduct(features *Features, product string) {
 	if product == "" {
-		slog.Warn("could not resolve product name; omitting npu.product and npu.family labels")
+		slog.Warn("could not resolve product name; omitting npu.product label")
 		return
 	}
 	features.NPUProduct = ptr(product)
-
-	family, err := familyFromProduct(product)
-	if err != nil {
-		slog.Warn("cannot derive family; omitting npu.family label", "product", product)
-		return
-	}
-	features.NPUFamily = ptr(family)
 }
 
 func (c *FeaturesCollector) save(features Features) error {

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -8,26 +8,12 @@ func TestApplyProduct(t *testing.T) {
 	if f.NPUProduct == nil || *f.NPUProduct != "RBLN-CR13" {
 		t.Fatalf("NPUProduct = %v, want RBLN-CR13", f.NPUProduct)
 	}
-	if f.NPUFamily == nil || *f.NPUFamily != DeviceFamilyREBEL {
-		t.Fatalf("NPUFamily = %v, want %s", f.NPUFamily, DeviceFamilyREBEL)
-	}
 }
 
 func TestApplyProductEmptyIsNonFatal(t *testing.T) {
 	f := newFeatures()
 	applyProduct(&f, "")
-	if f.NPUProduct != nil || f.NPUFamily != nil {
-		t.Fatal("empty product must leave product/family labels unset")
-	}
-}
-
-func TestApplyProductUnknownFamily(t *testing.T) {
-	f := newFeatures()
-	applyProduct(&f, "RBLN-XX99")
-	if f.NPUProduct == nil || *f.NPUProduct != "RBLN-XX99" {
-		t.Fatalf("NPUProduct = %v, want RBLN-XX99", f.NPUProduct)
-	}
-	if f.NPUFamily != nil {
-		t.Fatal("unknown prefix must leave family label unset")
+	if f.NPUProduct != nil {
+		t.Fatal("empty product must leave the product label unset")
 	}
 }

--- a/internal/collector/device.go
+++ b/internal/collector/device.go
@@ -1,30 +1,8 @@
 package collector
 
 import (
-	"fmt"
 	"strings"
 )
-
-const (
-	DeviceFamilyATOM  = "ATOM"
-	DeviceFamilyREBEL = "REBEL"
-
-	productPrefix = "RBLN-"
-)
-
-// familyFromProduct derives the device family from a product name such as
-// "RBLN-CA25" (the RBLN- prefix is optional): CA* -> ATOM, CR* -> REBEL.
-func familyFromProduct(product string) (string, error) {
-	name := strings.TrimPrefix(product, productPrefix)
-	switch {
-	case strings.HasPrefix(name, "CA"):
-		return DeviceFamilyATOM, nil
-	case strings.HasPrefix(name, "CR"):
-		return DeviceFamilyREBEL, nil
-	default:
-		return "", fmt.Errorf("unknown product name: %s", product)
-	}
-}
 
 // productLabelFromPCIIDsName strips the " (PF)" / " (VF)" suffix pci.ids
 // entries carry — parentheses and spaces are not valid in label values.

--- a/internal/collector/device_test.go
+++ b/internal/collector/device_test.go
@@ -2,34 +2,6 @@ package collector
 
 import "testing"
 
-func TestFamilyFromProduct(t *testing.T) {
-	cases := []struct {
-		product string
-		want    string
-	}{
-		{"RBLN-CA25", DeviceFamilyATOM},
-		{"RBLN-CR13", DeviceFamilyREBEL},
-		{"CA02", DeviceFamilyATOM},
-	}
-	for _, tc := range cases {
-		t.Run(tc.product, func(t *testing.T) {
-			got, err := familyFromProduct(tc.product)
-			if err != nil {
-				t.Fatalf("familyFromProduct(%q) error: %v", tc.product, err)
-			}
-			if got != tc.want {
-				t.Fatalf("familyFromProduct(%q) = %q, want %q", tc.product, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestFamilyFromProductUnknown(t *testing.T) {
-	if _, err := familyFromProduct("RBLN-XX99"); err == nil {
-		t.Fatal("expected error for unknown product prefix")
-	}
-}
-
 func TestProductLabelFromPCIIDsName(t *testing.T) {
 	cases := map[string]string{
 		"RBLN-CA22 (PF)": "RBLN-CA22",


### PR DESCRIPTION
  ## Motivation

`rebellions.ai/npu.family` had two writers with incompatible vocabularies: this repo emitted uppercase `ATOM`/`REBEL`, while rbln-npu-operator's always-on `npu-family` NodeFeatureRule writes lowercase `atom`/`rebel100` to route per-family RBLNDriver instances. Whenever this repo's value won, the operator's driver-routing selector could not match. Dropping emission here leaves a single authoritative producer for the label.

  ## Summary of Changes

  - Stop emitting the `rebellions.ai/npu.family` label (`Features.NPUFamily`, its `toPlainText` block, and family derivation in `applyProduct`)
  - Remove orphaned code: `familyFromProduct`, `DeviceFamily*`/`productPrefix` constants, and their tests
  - Drop `npu.family` from the README label docs
  - `npu.product` resolution is unchanged
